### PR TITLE
[fix]플레이어 콤보 공격수정.

### DIFF
--- a/Assets/Polygon Arsenal/Upgrades/Polygon Arsenal 2019.4 URP.unitypackage.meta
+++ b/Assets/Polygon Arsenal/Upgrades/Polygon Arsenal 2019.4 URP.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 7e1f14168420ddc4cb8c78ae96e1c491
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Resources/Player/Animation/PlayerAnimation/Attack/Attack_Legend_Anim.anim
+++ b/Assets/Resources/Player/Animation/PlayerAnimation/Attack/Attack_Legend_Anim.anim
@@ -44229,7 +44229,7 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events:
-  - time: 0.5
+  - time: 1
     functionName: FourthAttack
     data: 
     objectReferenceParameter: {fileID: 0}

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -33,6 +33,7 @@ public class Player : MonoBehaviour, IHit
     float _currentHP;
     [SerializeField] float _currentSkill;
     float _currentStamina;
+    public float CurrentAtk { get; set; }
     public bool IsActiveStaminaRecovery { get; set; } = true;
     bool _isPlayerAlive = true;
     public bool[] IsSkillAcitve { get; set; } = new bool[4] { false, false, false, false };
@@ -184,6 +185,14 @@ public class Player : MonoBehaviour, IHit
         {
             CurrentSkill = 100;
         }
+        else if (Input.GetKeyDown(KeyCode.O))
+        {
+            CurrentAmmo += 1;
+        }
+        else if (Input.GetKeyDown(KeyCode.P))
+        {
+            CurrentAmmo += 10;
+        }
     }
 
     private void InitializePlayer()
@@ -262,6 +271,7 @@ public class Player : MonoBehaviour, IHit
             {
                 _playerStat = stat;
                 Debug.Log("Player의 스탯을 성공적으로 받아왔습니다.");
+                CurrentAtk = _playerStat.Atk_Power;                
                 CurrentHP = _playerStat.HP;
                 HP = _playerStat.HP;
                 CurrentStamina = 100;
@@ -305,7 +315,10 @@ public class Player : MonoBehaviour, IHit
     //Ground, AttackGizmos
     private void OnDrawGizmos()
     {
-        if (Application.isPlaying &&_state.CurrentState is PlayerFirstComboAttack)
+        if (!Application.isPlaying)
+            return;
+
+        if (_state.CurrentState is PlayerFirstComboAttack)
         {
             PlayerFirstComboAttack firstCombo = _state.CurrentState as PlayerFirstComboAttack;
 
@@ -322,7 +335,7 @@ public class Player : MonoBehaviour, IHit
 
             Gizmos.matrix = originalMatrix; 
         }
-        else if(Application.isPlaying && _state.CurrentState is PlayerSecondComboAttack)
+        else if(_state.CurrentState is PlayerSecondComboAttack)
         {
             PlayerSecondComboAttack secondCombo = _state.CurrentState as PlayerSecondComboAttack;
 
@@ -339,7 +352,7 @@ public class Player : MonoBehaviour, IHit
 
             Gizmos.matrix = originalMatrix;
         }
-        else if(Application.isPlaying && _state.CurrentState is PlayerThirdComboAttack)
+        else if(_state.CurrentState is PlayerThirdComboAttack)
         {
             PlayerThirdComboAttack thirdCombo = _state.CurrentState as PlayerThirdComboAttack;
 
@@ -347,12 +360,13 @@ public class Player : MonoBehaviour, IHit
 
             // 부채꼴의 중심 방향
             Vector3 forward = transform.forward;
+            float angle = thirdCombo._angle -10;
 
             // 부채꼴의 외곽을 그리기 위한 각도 계산
             for (int i = 0; i <= thirdCombo._segments; i++)
             {
                 if (i != 0 && i != thirdCombo._segments) continue;
-                float currentAngle = -thirdCombo._angle / 2 + (thirdCombo._angle / thirdCombo._segments) * i;
+                float currentAngle = -angle / 2 + (angle / thirdCombo._segments) * i;
                 Quaternion rotation = Quaternion.AngleAxis(currentAngle, transform.up);
 
                 // 외곽 지점 계산
@@ -366,8 +380,8 @@ public class Player : MonoBehaviour, IHit
             // 부채꼴의 바닥 원호를 그리기 위한 계산
             for (int i = 0; i < thirdCombo._segments; i++)
             {
-                float angle1 = -thirdCombo._angle  / 2 + (thirdCombo._angle  / thirdCombo._segments) * i;
-                float angle2 = -thirdCombo._angle / 2 + (thirdCombo._angle / thirdCombo._segments) * (i + 1);
+                float angle1 = -angle  / 2 + (angle  / thirdCombo._segments) * i;
+                float angle2 = -angle / 2 + (angle / thirdCombo._segments) * (i + 1);
 
                 Quaternion rot1 = Quaternion.AngleAxis(angle1, transform.up);
                 Quaternion rot2 = Quaternion.AngleAxis(angle2, transform.up);
@@ -389,11 +403,22 @@ public class Player : MonoBehaviour, IHit
             //Gizmos.DrawWireSphere(transform.position, thirdCombo._range);
         }
 
-        else if(Application.isPlaying && _state.CurrentState is PlayerFourthComboAttack)
+        else if(_state.CurrentState is PlayerFourthComboAttack)
         {
             PlayerFourthComboAttack fourthCombo = _state.CurrentState as PlayerFourthComboAttack;
 
+            Vector3 boxposition = fourthCombo._boxPosition;
+            Vector3 boxSize = fourthCombo._boxSize;
+            Quaternion boxrotation = transform.rotation;
 
+            Matrix4x4 originalMatrix = Gizmos.matrix;
+
+            Gizmos.matrix = Matrix4x4.TRS(boxposition, boxrotation, Vector3.one);
+
+            Gizmos.color = Color.red;
+            Gizmos.DrawWireCube(Vector3.zero, boxSize);
+
+            Gizmos.matrix = originalMatrix;
         }
 
         Vector3 GizmoPosition = new Vector3(transform.position.x, transform.position.y, transform.position.z);

--- a/Assets/Scripts/Player/PlayerEffect.cs
+++ b/Assets/Scripts/Player/PlayerEffect.cs
@@ -20,6 +20,7 @@ public class PlayerEffect : MonoBehaviour
     [SerializeField] private Gradient[] _gradients;
     [SerializeField] private Material _material;
 
+    private Player _player;
     private Light _effectLight;
     private ParticleSystem[] particleSystems;
     private WaitForSeconds _returnTime = new WaitForSeconds(0.5f);
@@ -29,8 +30,15 @@ public class PlayerEffect : MonoBehaviour
         InitializePlayerEffect();
     }
 
+    private void Update()
+    {
+        
+    }
+
     private void InitializePlayerEffect()
     {
+        //_attackEffectDic ??= new(); 또 다른 초기화 방법.
+
         var childTransformList = new List<Transform>();
 
         foreach(Transform childTransform in _effectPosition.transform)
@@ -60,10 +68,11 @@ public class PlayerEffect : MonoBehaviour
         _effectLight = fourthAttackEffectTrans.GetComponentInChildren<Light>();
         fourthAttackEffectTrans.gameObject.SetActive(false);
 
+        _player = gameObject.GetComponent<Player>();    
     }
 
     public void ChangeColor(int index)
-    {       
+    {
         foreach (var item in particleSystems)
         {
             var colorOverLifetime = item.colorOverLifetime; // ColorOverLifetimeModule 가져오기
@@ -113,8 +122,13 @@ public class PlayerEffect : MonoBehaviour
         StartCoroutine(ReturnThirdEffect(thirdEffect));
     }
 
-    public void Active_FourthEffect()
+    public void Active_FourthEffect(float currentAmmo)
     {
+        if (currentAmmo <= 1)
+        {
+            return;
+        }
+
         GameObject fourthEffect = GetAttackEffect(AttackType.fourthAttack);
         ParticleSystem effectParticle = fourthEffect.GetComponentInChildren<ParticleSystem>();
 

--- a/Assets/Scripts/Player/State/Combo/PlayerComboAttack.cs
+++ b/Assets/Scripts/Player/State/Combo/PlayerComboAttack.cs
@@ -3,7 +3,16 @@ using Zenject;
 
 public class PlayerComboAttack : PlayerState
 {
-    public PlayerComboAttack(Player player) : base(player) { }
+    public PlayerComboAttack(Player player) : base(player)
+    {
+        if (!_isLoadData)
+        {
+            _isLoadData = true;
+            Debug.Log("데이터 로드중");
+        }
+    }
+
+    private bool _isLoadData = false;
     
     #region AnimatorStringToHash
     protected AnimatorStateInfo _animatorStateInfo;
@@ -17,6 +26,7 @@ public class PlayerComboAttack : PlayerState
 
     protected void OnComboAttackUpdate(string attackName, State nextCombo)
     {
+        Debug.Log(_player.CurrentAmmo);
         _animatorStateInfo = _animator.GetCurrentAnimatorStateInfo(0);
 
         if (_animatorStateInfo.IsName(attackName) && _animatorStateInfo.normalizedTime >= 0.99f)
@@ -27,7 +37,14 @@ public class PlayerComboAttack : PlayerState
         }
         else
             AttackRotation();
-        
+
+        if(nextCombo is State.FourthComboAttack)
+        {
+            if(_player.CurrentAmmo <= 1)
+            {
+                return;
+            }
+        }
 
         if (_inputSystem.IsAttack && _player.IsNext)
         {

--- a/Assets/Scripts/Player/State/Combo/PlayerFirstComboAttack.cs
+++ b/Assets/Scripts/Player/State/Combo/PlayerFirstComboAttack.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 public class PlayerFirstComboAttack : PlayerComboAttack
@@ -7,6 +8,31 @@ public class PlayerFirstComboAttack : PlayerComboAttack
         PlayerAnimationEvent _event;
         _event = player.GetComponentInChildren<PlayerAnimationEvent>();
         _event.AddEvent(AttackType.firstAttack, FirstAttack);
+        player.StartCoroutine(LoadData("A201"));
+    }
+
+    private PC_Attack _attackData;
+
+    private IEnumerator LoadData(string idStr)
+    {
+        while (true)
+        {
+            var firstComboData = _player.dataManager.GetData(idStr) as PC_Attack;
+            if(firstComboData == null )
+            {
+                Debug.Log("1번 콤보 데이터를 가져오지 못했습니다.");
+                yield return new WaitForSeconds(1f);
+            }
+            else
+            {
+                _attackData = firstComboData;
+                PC_Type1_Atk_Multiplier = _attackData.Atk_Multiplier;
+                
+                Debug.Log("1번 콤보 데이터를 성공적으로 가져왔습니다.");
+                yield break;
+            }
+
+        }
     }
 
     #region Overlap
@@ -16,6 +42,9 @@ public class PlayerFirstComboAttack : PlayerComboAttack
     private Vector3 _additionalPosition = new Vector3(0f, 1f, 0.5f);
     private LayerMask _enemyLayer;
     #endregion
+
+    private float _currentAtk;
+    private float PC_Type1_Atk_Multiplier;
 
     public override void StateEnter()
     {
@@ -58,7 +87,9 @@ public class PlayerFirstComboAttack : PlayerComboAttack
 
             if (hit != null)
             {
-                hit.Hit(10f, 5f, _player.transform);
+                _currentAtk = _player.CurrentAtk * PC_Type1_Atk_Multiplier;
+
+                hit.Hit(_currentAtk, 5f, _player.transform);
 
                 GameObject hitEffect = _effect.GetHitEffect();
                 ParticleSystem hitParticle = hitEffect.GetComponent<ParticleSystem>();

--- a/Assets/Scripts/Player/State/Combo/PlayerFourthComboAttack.cs
+++ b/Assets/Scripts/Player/State/Combo/PlayerFourthComboAttack.cs
@@ -1,6 +1,8 @@
+using Cinemachine;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Zenject.SpaceFighter;
 
 public class PlayerFourthComboAttack : PlayerComboAttack
 {
@@ -8,17 +10,33 @@ public class PlayerFourthComboAttack : PlayerComboAttack
     {
         PlayerAnimationEvent _event;
         _event = player.GetComponentInChildren<PlayerAnimationEvent>();
-        _event.AddEvent(AttackType.fourthAttack, ChargeAttack);
+        _event.AddEvent(AttackType.fourthAttack, FourthAttack);
+        player.StartCoroutine(GetCamera());
     }
     
     private float _maxDelayTime = 2f;
     private float _currentDelayTime;
     private float _maxGauge = 4f;
     private float _gauge;
+    private int _chargeCount;
     private bool _isFillingGauge = true;
-    
+
+    private CinemachineVirtualCamera _virtualCamera;
+    private float _maxView = 90f;
+    private float _currentView;
+
+    #region Overlap
+    public Vector3 _forward { get; private set; }
+    public Vector3 _boxPosition { get; private set; }
+    public Vector3 _boxSize { get; private set; } = new Vector3(2f, 1.5f, 10f);
+    public Vector3 _additionalPosition = new Vector3(0f, 1f, 1f);
+    private LayerMask _enemyLayer;
+    #endregion
+
     public override void StateEnter()
     {
+        _chargeCount = _player.CurrentAmmo - 1;
+
         _currentDelayTime = 0f;
 
         _gauge = 0f;
@@ -36,20 +54,30 @@ public class PlayerFourthComboAttack : PlayerComboAttack
         //4초면 4초에 0.3f, 0.03f
         if (_animatorStateInfo.IsName("Attack_Legend_Anim") &&_animatorStateInfo.normalizedTime >= 0.3f)
         {
-            _animator.speed = 0.05f;
+            _animator.speed = 0.03f;
         }
         
         if (!_isFillingGauge)
         {
             Debug.Log(Mathf.Round(_currentDelayTime));
 
-            EndState();
+            if (!_inputSystem.IsAttack || _currentDelayTime >= _maxDelayTime)
+            {
+                _animator.speed = 1f;
+
+                _state.ChangeState(State.Idle);
+
+                return;
+            }
+
+            _currentDelayTime += Time.deltaTime;
         }
     }
 
     public override void StateExit()
     {
         _effect.DeActive_FourthEffect();
+
         ComboAnimation(_fourthCombo, false);
 
         _inputSystem.SetAttack(false);
@@ -59,7 +87,7 @@ public class PlayerFourthComboAttack : PlayerComboAttack
 
     private IEnumerator GaugeAmount()
     {
-        _effect.Active_FourthEffect();
+        _effect.Active_FourthEffect(_player.CurrentAmmo);
 
         int index = 0;
         
@@ -67,12 +95,15 @@ public class PlayerFourthComboAttack : PlayerComboAttack
 
         while (_isFillingGauge)
         {
-            yield return new WaitForSeconds(0.5f);
-            index += index == 3 ? 0 : 1;
-            _effect.ChangeColor(index);
-            _gauge += 1f;
+            _chargeCount--;
 
-            Debug.Log(_gauge);
+            yield return new WaitForSeconds(1f);
+
+            index += index == 3 ? 0 : 1;
+
+            _effect.ChangeColor(index);
+
+            _gauge += 1f;
 
             if(_gauge >= _maxGauge)
             {
@@ -80,10 +111,8 @@ public class PlayerFourthComboAttack : PlayerComboAttack
 
                 yield break;
             }
-            else if (!_inputSystem.IsAttack)
+            else if(_chargeCount < 0 || !_inputSystem.IsAttack)
             {
-                Debug.Log("취소");
-
                 _animator.speed = 1f;
 
                 _state.ChangeState(State.Idle);
@@ -93,29 +122,51 @@ public class PlayerFourthComboAttack : PlayerComboAttack
         }
     }
 
-    private void EndState()
+    private void FourthAttack()
     {
-        if(!_inputSystem.IsAttack || _currentDelayTime >= _maxDelayTime)
+        _forward = _player.transform.forward;
+
+        _boxPosition = _player.transform.position + _player.transform.TransformDirection(_additionalPosition) + _forward;
+
+        _enemyLayer = LayerMask.GetMask("Monster");
+
+        Collider[] colliders = Physics.OverlapBox(_boxPosition, _boxSize /2f, _player.transform.rotation, _enemyLayer);
+
+        foreach(var target in  colliders)
         {
-            _animator.speed = 1f;
+            IHit hit = target.gameObject.GetComponent<IHit>();
 
-            _state.ChangeState(State.Idle);
+            Vector3 directionToPlayer = (_player.transform.position - target.transform.position).normalized;
+            Vector3 hitPosition = target.transform.position + directionToPlayer * 1f;
 
-            return;
+            if(hit != null)
+            {
+                hit.Hit(10f, 5f, _player.transform);
+
+                GameObject hitEffect = _effect.GetHitEffect();
+                ParticleSystem hitParticle = hitEffect.GetComponent<ParticleSystem>();
+
+                hitEffect.transform.position = hitPosition;
+                Quaternion lookRotation = Quaternion.LookRotation(_player.transform.position);
+                hitEffect.transform.rotation = lookRotation;
+
+                hitParticle.Play();
+                _effect.ReturnHit(hitEffect);
+            }
         }
 
-        _currentDelayTime += Time.deltaTime;
     }
 
-    private void ChargeAttack()
+    
+
+    IEnumerator GetCamera()
     {
-        
-    }
+        yield return new WaitForSeconds(2f);
 
+        CinemachineBrain brain = _player.MainCamera.GetComponent<CinemachineBrain>();
 
+        var cinemaChineObject = brain.ActiveVirtualCamera.VirtualCameraGameObject;
 
-    private void FourthAttack(float time)
-    {
-
+        _virtualCamera = cinemaChineObject.GetComponent<CinemachineVirtualCamera>();
     }
 }


### PR DESCRIPTION
데이터 테스트 완료.
현재 보유하고 있는 자원 수량이 1이하라면 차지 이펙트가 나가지 않도록 수정.
3타 -> 4타 차지 공격으로 넘어갈 때 자원 수량이 1이하라면 차지 공격이 발사되지 않도록 수정. 현재 보유하고 있는 자원 수량에 따라 차지 단계가 결정되도록 수정.
기존에는 차지 간격이 0.5초였는데 기획서에 따라 1초로 변경함.
풀 차지 상태가 되었을 때 공격이 즉시 나가지 않고 2초간 지연 후 공격이 발사되도록 수정 풀 차지 상태가 가능하더라도 차지 도중에 공격을 취소하면 해당 단계의 공격이 나가도록 수정.(이펙트만 구현) 각 모든 콤보 공격의 범위는 외부에서 기즈모로 확인할 수 있도록 수정함.