### PR TITLE
[feat] Stage 자원 생성 수정.

### DIFF
--- a/Assets/Polytope Studio/Lowpoly_Environments/SRP/PT_Nature_Free_URP_16.0.5.unitypackage.meta
+++ b/Assets/Polytope Studio/Lowpoly_Environments/SRP/PT_Nature_Free_URP_16.0.5.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: b2b57b8ebc2bca44eacd6d991d27ea97
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Prefabs/Stage/Map.meta
+++ b/Assets/Prefabs/Stage/Map.meta
@@ -1,5 +1,6 @@
 fileFormatVersion: 2
-guid: fae09cfceda875146a4f9a54fa30589e
+guid: 3c5bc58c3157a4b4bac00397b00cb8a1
+folderAsset: yes
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Prefabs/Stage/Map/Stage.prefab
+++ b/Assets/Prefabs/Stage/Map/Stage.prefab
@@ -1,0 +1,149 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1323274783773479836
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3560944200217787947}
+  - component: {fileID: 6767242955523599247}
+  - component: {fileID: 8188335126287835600}
+  m_Layer: 0
+  m_Name: Stage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3560944200217787947
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323274783773479836}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6767242955523599247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323274783773479836}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2c91ee8917d4f24cb3af6dc6c763e7b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _level: 2
+  _partitions:
+  - _centerPosition: {fileID: 0}
+    _mapSizeX: 10
+    _mapSizeZ: 10
+    _maxResourceCount: 0
+    _resourceA_Ratio: 0
+    _resourceB_Ration: 0
+    _resourceC_Ration: 0
+    _resourceCountArray: 
+  - _centerPosition: {fileID: 0}
+    _mapSizeX: 10
+    _mapSizeZ: 10
+    _maxResourceCount: 0
+    _resourceA_Ratio: 0
+    _resourceB_Ration: 0
+    _resourceC_Ration: 0
+    _resourceCountArray: 
+  - _centerPosition: {fileID: 0}
+    _mapSizeX: 10
+    _mapSizeZ: 10
+    _maxResourceCount: 0
+    _resourceA_Ratio: 0
+    _resourceB_Ration: 0
+    _resourceC_Ration: 0
+    _resourceCountArray: 
+  - _centerPosition: {fileID: 0}
+    _mapSizeX: 10
+    _mapSizeZ: 10
+    _maxResourceCount: 0
+    _resourceA_Ratio: 0
+    _resourceB_Ration: 0
+    _resourceC_Ration: 0
+    _resourceCountArray: 
+  - _centerPosition: {fileID: 0}
+    _mapSizeX: 10
+    _mapSizeZ: 10
+    _maxResourceCount: 0
+    _resourceA_Ratio: 0
+    _resourceB_Ration: 0
+    _resourceC_Ration: 0
+    _resourceCountArray: 
+  - _centerPosition: {fileID: 0}
+    _mapSizeX: 10
+    _mapSizeZ: 10
+    _maxResourceCount: 0
+    _resourceA_Ratio: 0
+    _resourceB_Ration: 0
+    _resourceC_Ration: 0
+    _resourceCountArray: 
+  - _centerPosition: {fileID: 0}
+    _mapSizeX: 10
+    _mapSizeZ: 10
+    _maxResourceCount: 0
+    _resourceA_Ratio: 0
+    _resourceB_Ration: 0
+    _resourceC_Ration: 0
+    _resourceCountArray: 
+  - _centerPosition: {fileID: 0}
+    _mapSizeX: 10
+    _mapSizeZ: 10
+    _maxResourceCount: 0
+    _resourceA_Ratio: 0
+    _resourceB_Ration: 0
+    _resourceC_Ration: 0
+    _resourceCountArray: 
+  - _centerPosition: {fileID: 0}
+    _mapSizeX: 10
+    _mapSizeZ: 10
+    _maxResourceCount: 0
+    _resourceA_Ratio: 0
+    _resourceB_Ration: 0
+    _resourceC_Ration: 0
+    _resourceCountArray: 
+  _monsterSpawncount: 10
+  _portal: {fileID: 0}
+--- !u!114 &8188335126287835600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323274783773479836}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 700dcb4f978c9c0439d20e5421c36ae6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _monsterCount: 30
+  _meleeAttackmonster: {fileID: 3379560720758915511, guid: dfcd9db998287d34386f0f5c807b39de,
+    type: 3}
+  _meleeExplosionmonster: {fileID: 3379560720758915511, guid: dfcd9db998287d34386f0f5c807b39de,
+    type: 3}
+  _chargeMonster: {fileID: 3379560720758915511, guid: dfcd9db998287d34386f0f5c807b39de,
+    type: 3}
+  _longRangeMonster: {fileID: 3379560720758915511, guid: dfcd9db998287d34386f0f5c807b39de,
+    type: 3}
+  _itemCount: 50
+  _items:
+  - {fileID: 1513480958163031010, guid: 0b972934f19a9ea42947818b71662f3e, type: 3}
+  - {fileID: 1513480958163031010, guid: 4d6fa6f7b92c4734ba8d15bca55e536d, type: 3}
+  - {fileID: 1513480958163031010, guid: 4d47a7d3e2a363145bd36e7359fa7a87, type: 3}

--- a/Assets/Prefabs/Stage/Map/Stage.prefab.meta
+++ b/Assets/Prefabs/Stage/Map/Stage.prefab.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: bd960d1781917284bb89077cf66b65fe
-DefaultImporter:
+guid: df055a838efe5724abfa0644a31f8dd3
+PrefabImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Assets/Prefabs/UI/MapChoiceUI/GameUI.prefab
+++ b/Assets/Prefabs/UI/MapChoiceUI/GameUI.prefab
@@ -165,6 +165,7 @@ GameObject:
   - component: {fileID: 6655673329365675161}
   - component: {fileID: 2489867648642232704}
   - component: {fileID: 2885673721415708816}
+  - component: {fileID: 1429933534526332838}
   m_Layer: 0
   m_Name: Quantity_Text
   m_TagString: Untagged
@@ -289,6 +290,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &1429933534526332838
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 663861439744163608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7791cbc0d2a44c41992044d8727e8f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IDStr: 
 --- !u!1 &1042800238459438358
 GameObject:
   m_ObjectHideFlags: 0
@@ -335,6 +349,7 @@ GameObject:
   - component: {fileID: 4694251675187892202}
   - component: {fileID: 4608642334139355891}
   - component: {fileID: 3851455451762988003}
+  - component: {fileID: 5831507699990258836}
   m_Layer: 0
   m_Name: Quantity_Text
   m_TagString: Untagged
@@ -459,6 +474,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &5831507699990258836
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1463217775206800491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7791cbc0d2a44c41992044d8727e8f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IDStr: 
 --- !u!1 &1991155371509731019
 GameObject:
   m_ObjectHideFlags: 0
@@ -702,6 +730,7 @@ GameObject:
   - component: {fileID: 8240219992226380359}
   - component: {fileID: 3130892002806924099}
   - component: {fileID: 6584077242903595564}
+  - component: {fileID: 5601813811103156308}
   m_Layer: 0
   m_Name: Normal_Text
   m_TagString: Untagged
@@ -826,6 +855,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &5601813811103156308
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2471460370891614305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7791cbc0d2a44c41992044d8727e8f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IDStr: 
 --- !u!1 &2626722759457054003
 GameObject:
   m_ObjectHideFlags: 0
@@ -912,6 +954,7 @@ GameObject:
   - component: {fileID: 8880071194208026450}
   - component: {fileID: 8059597251180813262}
   - component: {fileID: 8901913318791640094}
+  - component: {fileID: 6190676316116029151}
   m_Layer: 0
   m_Name: Boss_Text
   m_TagString: Untagged
@@ -1036,6 +1079,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &6190676316116029151
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3173993311620195849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7791cbc0d2a44c41992044d8727e8f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IDStr: 
 --- !u!1 &3231711112898676244
 GameObject:
   m_ObjectHideFlags: 0
@@ -1155,6 +1211,7 @@ GameObject:
   - component: {fileID: 7461075125736763172}
   - component: {fileID: 1827171197165875773}
   - component: {fileID: 1431400446202917677}
+  - component: {fileID: 4272859676683211867}
   m_Layer: 0
   m_Name: Quantity_Text
   m_TagString: Untagged
@@ -1279,6 +1336,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &4272859676683211867
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3665967052892191909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7791cbc0d2a44c41992044d8727e8f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IDStr: 
 --- !u!1 &3670501075305727156
 GameObject:
   m_ObjectHideFlags: 0
@@ -1290,6 +1360,7 @@ GameObject:
   - component: {fileID: 7126802613424821906}
   - component: {fileID: 4309787523964579734}
   - component: {fileID: 5468229788726077177}
+  - component: {fileID: 3978007947660087046}
   m_Layer: 0
   m_Name: Normal_Text
   m_TagString: Untagged
@@ -1414,6 +1485,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &3978007947660087046
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3670501075305727156}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7791cbc0d2a44c41992044d8727e8f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IDStr: 
 --- !u!1 &3764508772382238264
 GameObject:
   m_ObjectHideFlags: 0
@@ -1716,6 +1800,7 @@ GameObject:
   - component: {fileID: 7691097608727878251}
   - component: {fileID: 3716676244453352303}
   - component: {fileID: 4879711443893479936}
+  - component: {fileID: 1907377880277831457}
   m_Layer: 0
   m_Name: Normal_Text
   m_TagString: Untagged
@@ -1840,6 +1925,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &1907377880277831457
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4227478133816576077}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7791cbc0d2a44c41992044d8727e8f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IDStr: 
 --- !u!1 &4243902408395559192
 GameObject:
   m_ObjectHideFlags: 0
@@ -2845,6 +2943,7 @@ GameObject:
   - component: {fileID: 8143275338181827963}
   - component: {fileID: 3686208428839551388}
   - component: {fileID: 9135117399652666255}
+  - component: {fileID: 6146358374926854645}
   m_Layer: 0
   m_Name: Quality_Text
   m_TagString: Untagged
@@ -2969,6 +3068,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &6146358374926854645
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7157201037041072576}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7791cbc0d2a44c41992044d8727e8f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IDStr: 
 --- !u!1 &7157756113117514294
 GameObject:
   m_ObjectHideFlags: 0
@@ -3127,6 +3239,7 @@ GameObject:
   - component: {fileID: 8423216645521470581}
   - component: {fileID: 3949643844017481874}
   - component: {fileID: 8872526463232483969}
+  - component: {fileID: 5987698549417660813}
   m_Layer: 0
   m_Name: Quality_Text
   m_TagString: Untagged
@@ -3251,6 +3364,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &5987698549417660813
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7400684413342961870}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7791cbc0d2a44c41992044d8727e8f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IDStr: 
 --- !u!1 &7468005057549647299
 GameObject:
   m_ObjectHideFlags: 0
@@ -3486,6 +3612,7 @@ GameObject:
   - component: {fileID: 8004851044687699849}
   - component: {fileID: 3259554250967532398}
   - component: {fileID: 6976705548314544509}
+  - component: {fileID: 3243215472276931663}
   m_Layer: 0
   m_Name: Quality_Text
   m_TagString: Untagged
@@ -3610,6 +3737,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &3243215472276931663
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9027241390272379698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7791cbc0d2a44c41992044d8727e8f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IDStr: 
 --- !u!1 &9117673831266776245
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/TestScene/Stage.unity
+++ b/Assets/Scenes/TestScene/Stage.unity
@@ -215,7 +215,7 @@ Transform:
   m_GameObject: {fileID: 358579565}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -25, y: 0, z: -35}
+  m_LocalPosition: {x: -35, y: 0, z: -25}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -623,7 +623,7 @@ Transform:
   m_GameObject: {fileID: 698880264}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -35, y: 0, z: -25}
+  m_LocalPosition: {x: -25, y: 0, z: -35}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -802,7 +802,7 @@ Transform:
   m_GameObject: {fileID: 919514919}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -35, y: 0, z: -15}
+  m_LocalPosition: {x: -15, y: 0, z: -35}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -833,7 +833,7 @@ Transform:
   m_GameObject: {fileID: 932135874}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -25, y: 0, z: -15}
+  m_LocalPosition: {x: -15, y: 0, z: -25}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -864,7 +864,7 @@ Transform:
   m_GameObject: {fileID: 1097737219}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -15, y: 0, z: -25}
+  m_LocalPosition: {x: -25, y: 0, z: -15}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1034,160 +1034,12 @@ Transform:
   m_GameObject: {fileID: 1784427661}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -15, y: 0, z: -35}
+  m_LocalPosition: {x: -35, y: 0, z: -15}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1442451416}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2116168198
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2116168199}
-  - component: {fileID: 2116168200}
-  - component: {fileID: 2116168201}
-  m_Layer: 0
-  m_Name: Stage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2116168199
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2116168198}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2116168200
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2116168198}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e2c91ee8917d4f24cb3af6dc6c763e7b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _level: 0
-  _partitions:
-  - _centerPosition: {fileID: 522421815}
-    _mapSizeX: 10
-    _mapSizeZ: 10
-    _maxResourceCount: 0
-    _resourceA_Ratio: 0
-    _resourceB_Ration: 0
-    _resourceC_Ration: 0
-    _resourceCountArray: 
-  - _centerPosition: {fileID: 358579566}
-    _mapSizeX: 10
-    _mapSizeZ: 10
-    _maxResourceCount: 0
-    _resourceA_Ratio: 0
-    _resourceB_Ration: 0
-    _resourceC_Ration: 0
-    _resourceCountArray: 
-  - _centerPosition: {fileID: 1784427662}
-    _mapSizeX: 10
-    _mapSizeZ: 10
-    _maxResourceCount: 0
-    _resourceA_Ratio: 0
-    _resourceB_Ration: 0
-    _resourceC_Ration: 0
-    _resourceCountArray: 
-  - _centerPosition: {fileID: 698880265}
-    _mapSizeX: 10
-    _mapSizeZ: 10
-    _maxResourceCount: 0
-    _resourceA_Ratio: 0
-    _resourceB_Ration: 0
-    _resourceC_Ration: 0
-    _resourceCountArray: 
-  - _centerPosition: {fileID: 1693765384}
-    _mapSizeX: 10
-    _mapSizeZ: 10
-    _maxResourceCount: 0
-    _resourceA_Ratio: 0
-    _resourceB_Ration: 0
-    _resourceC_Ration: 0
-    _resourceCountArray: 
-  - _centerPosition: {fileID: 1097737220}
-    _mapSizeX: 10
-    _mapSizeZ: 10
-    _maxResourceCount: 0
-    _resourceA_Ratio: 0
-    _resourceB_Ration: 0
-    _resourceC_Ration: 0
-    _resourceCountArray: 
-  - _centerPosition: {fileID: 919514920}
-    _mapSizeX: 10
-    _mapSizeZ: 10
-    _maxResourceCount: 0
-    _resourceA_Ratio: 0
-    _resourceB_Ration: 0
-    _resourceC_Ration: 0
-    _resourceCountArray: 
-  - _centerPosition: {fileID: 932135875}
-    _mapSizeX: 10
-    _mapSizeZ: 10
-    _maxResourceCount: 0
-    _resourceA_Ratio: 0
-    _resourceB_Ration: 0
-    _resourceC_Ration: 0
-    _resourceCountArray: 
-  - _centerPosition: {fileID: 518093139}
-    _mapSizeX: 10
-    _mapSizeZ: 10
-    _maxResourceCount: 0
-    _resourceA_Ratio: 0
-    _resourceB_Ration: 0
-    _resourceC_Ration: 0
-    _resourceCountArray: 
-  _monsterSpawncount: 10
-  _itemSpawncount: 9
-  _portal: {fileID: 0}
---- !u!114 &2116168201
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2116168198}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 700dcb4f978c9c0439d20e5421c36ae6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _monsterCount: 30
-  _meleeAttackmonster: {fileID: 3379560720758915511, guid: dfcd9db998287d34386f0f5c807b39de,
-    type: 3}
-  _meleeExplosionmonster: {fileID: 3379560720758915511, guid: dfcd9db998287d34386f0f5c807b39de,
-    type: 3}
-  _chargeMonster: {fileID: 3379560720758915511, guid: dfcd9db998287d34386f0f5c807b39de,
-    type: 3}
-  _longRangeMonster: {fileID: 3379560720758915511, guid: dfcd9db998287d34386f0f5c807b39de,
-    type: 3}
-  _itemCount: 50
-  _items:
-  - {fileID: 753838215648177663, guid: 5439feb06513d804c9147449a48e2852, type: 3}
-  - {fileID: 8596524637384289334, guid: 392574a03f0a9c44c804f0997b5e0ae5, type: 3}
-  - {fileID: 3642885453965512081, guid: ace596954f9e1df43b88467f238d5fd3, type: 3}
 --- !u!1001 &2126055217
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1256,12 +1108,130 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 351837e3e283f0f44bc7f062335b9c56, type: 3}
+--- !u!1001 &8141453893965959316
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1323274783773479836, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: m_Name
+      value: Stage
+      objectReference: {fileID: 0}
+    - target: {fileID: 3560944200217787947, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3560944200217787947, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3560944200217787947, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3560944200217787947, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3560944200217787947, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3560944200217787947, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3560944200217787947, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3560944200217787947, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3560944200217787947, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3560944200217787947, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6767242955523599247, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: _level
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6767242955523599247, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: _partitions.Array.data[0]._centerPosition
+      value: 
+      objectReference: {fileID: 522421815}
+    - target: {fileID: 6767242955523599247, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: _partitions.Array.data[1]._centerPosition
+      value: 
+      objectReference: {fileID: 358579566}
+    - target: {fileID: 6767242955523599247, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: _partitions.Array.data[2]._centerPosition
+      value: 
+      objectReference: {fileID: 1784427662}
+    - target: {fileID: 6767242955523599247, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: _partitions.Array.data[3]._centerPosition
+      value: 
+      objectReference: {fileID: 698880265}
+    - target: {fileID: 6767242955523599247, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: _partitions.Array.data[4]._centerPosition
+      value: 
+      objectReference: {fileID: 1693765384}
+    - target: {fileID: 6767242955523599247, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: _partitions.Array.data[5]._centerPosition
+      value: 
+      objectReference: {fileID: 1097737220}
+    - target: {fileID: 6767242955523599247, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: _partitions.Array.data[6]._centerPosition
+      value: 
+      objectReference: {fileID: 919514920}
+    - target: {fileID: 6767242955523599247, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: _partitions.Array.data[7]._centerPosition
+      value: 
+      objectReference: {fileID: 932135875}
+    - target: {fileID: 6767242955523599247, guid: df055a838efe5724abfa0644a31f8dd3,
+        type: 3}
+      propertyPath: _partitions.Array.data[8]._centerPosition
+      value: 
+      objectReference: {fileID: 518093139}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: df055a838efe5724abfa0644a31f8dd3, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 414633634}
-  - {fileID: 2116168199}
+  - {fileID: 8141453893965959316}
   - {fileID: 1442451416}
   - {fileID: 773391088}
   - {fileID: 167469728}


### PR DESCRIPTION
현재 스테이지에 따라 선택된 구역에 자원이 생성되어야 하는데 스테이지에 상관없이 모든 구역에 자원이 생성되던 문제 해결함. 몬스터 스폰 방식 변경 -> 리스트를 삭제하며 랜덤한 위치를 찾던 방식에서 간단한 셔플 로직을 넣어 랜덤한 구역을 선택하는 방식으로 변경함. 임시 데이터 작성.